### PR TITLE
Logo in title bar added for all pages

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="./css/pages/coc.css"></link>
 		<link rel="stylesheet" href="css/pages/navbar.css">
 		<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400&display=swap" rel="stylesheet">
+		<link rel="icon" type="image/x-icon" href="img/logos/favicon.ico"/>
 	</HEAD>
 	<BODY>
 		<nav>

--- a/discord.html
+++ b/discord.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="./css/pages/discord.css">
   <link rel="stylesheet" href="./css/pages/navbar.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/x-icon" href="img/logos/favicon.ico"/>
 </head>
 <body>
 <nav>

--- a/faq.html
+++ b/faq.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="./css/pages/faq.css">
   <link rel="stylesheet" href="css/pages/navbar.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/x-icon" href="img/logos/favicon.ico"/>
   <title>FAQ</title>
 </head>
 <body>


### PR DESCRIPTION
Logo now appears in the title bar of all pages of the website:
<img width="678" alt="rds_1" src="https://user-images.githubusercontent.com/78417808/106784997-f2c16e80-6672-11eb-8c9e-8a0f97c60c52.PNG">
<img width="518" alt="rds_2" src="https://user-images.githubusercontent.com/78417808/106785049-0371e480-6673-11eb-9232-ec1b7e260d61.PNG">
<img width="573" alt="rds_3" src="https://user-images.githubusercontent.com/78417808/106785063-05d43e80-6673-11eb-8ef3-09b8e27a3159.PNG">
