### PR TITLE
fix link to events site in navbar

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -63,7 +63,7 @@
             Welcome
           </a>
         </li>
-        <li><a href="./events.html">Events</a></li>
+        <li><a href="https://www.realdevsquad.com/events.html">Events</a></li>
         <li><a href="https://members.realdevsquad.com/">Members</a></li>
         <li><a href="https://crypto.realdevsquad.com/">Crypto</a></li>
         <li><a href="https://status.realdevsquad.com/">Status</a></li>

--- a/discord.html
+++ b/discord.html
@@ -63,7 +63,7 @@
             Welcome
           </a>
         </li>
-        <li><a href="./events.html">Events</a></li>
+        <li><a href="https://www.realdevsquad.com/events.html">Events</a></li>
         <li><a href="https://members.realdevsquad.com/">Members</a></li>
         <li><a href="https://crypto.realdevsquad.com/">Crypto</a></li>
         <li><a href="https://status.realdevsquad.com/">Status</a></li>

--- a/faq.html
+++ b/faq.html
@@ -63,7 +63,7 @@
             Welcome
           </a>
         </li>
-        <li><a href="./events.html">Events</a></li>
+        <li><a href="https://www.realdevsquad.com/events.html">Events</a></li>
         <li><a href="https://members.realdevsquad.com/">Members</a></li>
         <li><a href="https://crypto.realdevsquad.com/">Crypto</a></li>
         <li><a href="https://status.realdevsquad.com/">Status</a></li>


### PR DESCRIPTION
closes issue #207

- Fixed navbar link to events page in three pages: FAQ, Discord and Code of Conduct.

