### PR TITLE
Grammatical Mistakes Resolved

### DIFF
--- a/discord.html
+++ b/discord.html
@@ -177,35 +177,35 @@
                 disussion,progress-updates ,newcomers & Support.
                 <ol class="rds-channel-info">
                   <li class="channel-name">
-                    <b>#general:</b> It carries general discussions.
+                    <b>#general: </b> It carries general discussions.
                   </li>
                   <li class="channel-name">
-                    <b>#newcomers:</b> All info related to newcomers are floated
+                    <b>#newcomers: </b> All info related to newcomers are floated
                     in it.
                   </li>
                   <li class="channel-name">
-                    <b>#progress-updates:</b> All info related to current
+                    <b>#progress-updates: </b> All info related to current
                     ongoing task,discussions are posted here.
                   </li>
                   <li class="channel-name">
-                    <b>#support:</b> In case you are stuck on need some help
+                    <b>#support: </b> In case you are stuck on need some help
                     everyone is there to help you keep running.
                   </li>
                 </ol>
               </li>
 
               <li>
-                <strong>Text Channels:</strong> Contains multiple other channels
+                <strong>Text Channels: </strong> Contains multiple other channels
                 in it.
               </li>
 
               <li>
-                <strong>Learning:</strong> It contains different technology
+                <strong>Learning: </strong> It contains different technology
                 related channels plus channel for interview preparation.
               </li>
 
               <li>
-                <strong>Dev groups:</strong> It contains channels for different
+                <strong>Dev groups: </strong> It contains channels for different
                 projects.
               </li>
 


### PR DESCRIPTION
For a better difference between a heading and its definition, some sort of symbol is needed.
Here the punctuation mark of the semicolon was there, but, it does not have the space between which was making it hard for a user to understand it better, so I added a space to make it easier.